### PR TITLE
explicit compile against cpp14

### DIFF
--- a/src/bridge_px4/CMakeLists.txt
+++ b/src/bridge_px4/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(bridge_px4)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
turned on the compile option for cpp14. Seems like for those of us on 16.04 this was not compiling against 11 which was needed for the `using oneD` type aliasing when dealing with `eigen::vector`. 

This now compiles on 16.04, it will also compile if we set it to `c++11`.

Anyways, I bumped this to 14 rather than just 11 because might as well as 14 as some nice syntax for long numbers and some other features we might use but probably won't